### PR TITLE
fix: add return type to d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 import { Stream } from "stream";
-declare function StreamEvents(stream: Stream);
+declare function StreamEvents(stream: Stream): Stream;
 declare namespace StreamEvents {}
 export = StreamEvents


### PR DESCRIPTION
Missed this with the first PR.  Needed for npImplictAny.  Sorry for the trouble!