### PR TITLE
fix(types): preserve input stream type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
-declare function StreamEvents<StreamType>(stream: StreamType): StreamType;
-declare namespace StreamEvents {}
+import { Stream } from "stream";
+declare function StreamEvents<StreamType extends Stream>(stream: StreamType)
+  : StreamType;
+declare namespace StreamEvents { }
 export = StreamEvents

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import { Stream } from "stream";
-declare function StreamEvents(stream: Stream): Stream;
+declare function StreamEvents<StreamType>(stream: StreamType): StreamType;
 declare namespace StreamEvents {}
 export = StreamEvents


### PR DESCRIPTION
Fix type definition to communicate that the stream type doesn't change.